### PR TITLE
fix: syntax error when arrow function parameter is assignment pattern

### DIFF
--- a/__test__/__snapshot__/arrow-function/type.ts
+++ b/__test__/__snapshot__/arrow-function/type.ts
@@ -1,0 +1,170 @@
+const ArrowFunctionTypeSnapshot = {
+  AssignmentPattern: {
+    type: "Program",
+    start: 0,
+    end: 20,
+    loc: {
+      start: {
+        line: 1,
+        column: 0,
+        index: 0,
+      },
+      end: {
+        line: 1,
+        column: 20,
+        index: 20,
+      },
+    },
+    body: [
+      {
+        type: "ExpressionStatement",
+        start: 0,
+        end: 20,
+        loc: {
+          start: {
+            line: 1,
+            column: 0,
+            index: 0,
+          },
+          end: {
+            line: 1,
+            column: 20,
+            index: 20,
+          },
+        },
+        expression: {
+          type: "ArrowFunctionExpression",
+          start: 0,
+          end: 20,
+          loc: {
+            start: {
+              line: 1,
+              column: 0,
+              index: 0,
+            },
+            end: {
+              line: 1,
+              column: 20,
+              index: 20,
+            },
+          },
+          returnType: {
+            type: "TSTypeAnnotation",
+            start: 8,
+            end: 14,
+            loc: {
+              start: {
+                line: 1,
+                column: 8,
+                index: 8,
+              },
+              end: {
+                line: 1,
+                column: 14,
+                index: 14,
+              },
+            },
+            typeAnnotation: {
+              type: "TSVoidKeyword",
+              start: 10,
+              end: 14,
+              loc: {
+                start: {
+                  line: 1,
+                  column: 10,
+                  index: 10,
+                },
+                end: {
+                  line: 1,
+                  column: 14,
+                  index: 14,
+                },
+              },
+            },
+          },
+          id: null,
+          expression: false,
+          generator: false,
+          async: false,
+          params: [
+            {
+              type: "AssignmentPattern",
+              start: 1,
+              end: 7,
+              loc: {
+                start: {
+                  line: 1,
+                  column: 1,
+                  index: 1,
+                },
+                end: {
+                  line: 1,
+                  column: 7,
+                  index: 7,
+                },
+              },
+              left: {
+                type: "Identifier",
+                start: 1,
+                end: 2,
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 1,
+                    index: 1,
+                  },
+                  end: {
+                    line: 1,
+                    column: 2,
+                    index: 2,
+                  },
+                },
+                name: "x",
+              },
+              right: {
+                type: "Literal",
+                start: 5,
+                end: 7,
+                loc: {
+                  start: {
+                    line: 1,
+                    column: 5,
+                    index: 5,
+                  },
+                  end: {
+                    line: 1,
+                    column: 7,
+                    index: 7,
+                  },
+                },
+                value: 42,
+                raw: "42",
+              },
+            },
+          ],
+          body: {
+            type: "BlockStatement",
+            start: 18,
+            end: 20,
+            loc: {
+              start: {
+                line: 1,
+                column: 18,
+                index: 18,
+              },
+              end: {
+                line: 1,
+                column: 20,
+                index: 20,
+              },
+            },
+            body: [],
+          },
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+};
+
+export default ArrowFunctionTypeSnapshot;

--- a/__test__/arrow-function/type.test.ts
+++ b/__test__/arrow-function/type.test.ts
@@ -1,0 +1,13 @@
+import { equalNode, generateSource, parseSource } from '../utils'
+import ArrowFunctionTypeSnapshot from '../__snapshot__/arrow-function/type'
+
+describe('arrow-function type test', () => {
+  it('assignment pattern', () => {
+    const node = parseSource(generateSource([
+      `(x = 42): void => {}`
+    ]))
+
+    console.log(JSON.stringify(node, null, 2))
+    equalNode(node, ArrowFunctionTypeSnapshot.AssignmentPattern)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -4446,7 +4446,7 @@ function tsPlugin(options?: {
             if (!isBinding && node.left.type === 'TSTypeCastExpression') {
               node.left = this.typeCastToParameter(node.left)
             }
-          /* fall through */
+            return super.toAssignable(node, isBinding, refDestructuringErrors)
           default:
             return super.toAssignable(node, isBinding, refDestructuringErrors)
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4446,7 +4446,6 @@ function tsPlugin(options?: {
             if (!isBinding && node.left.type === 'TSTypeCastExpression') {
               node.left = this.typeCastToParameter(node.left)
             }
-            return node
           /* fall through */
           default:
             return super.toAssignable(node, isBinding, refDestructuringErrors)


### PR DESCRIPTION
fixes #7 