### PR TITLE
fix: syntax error in export default anonymous class

### DIFF
--- a/__test__/__snapshot__/export/normal.ts
+++ b/__test__/__snapshot__/export/normal.ts
@@ -701,6 +701,49 @@ const NormalExportSnapshot = {
     ],
     'sourceType': 'module'
   },
+  ExportDefaultAnonymousClass: {
+    type: "Program",
+    start: 0,
+    end: 23,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 1, column: 23, index: 23 },
+    },
+    body: [
+      {
+        type: "ExportDefaultDeclaration",
+        start: 0,
+        end: 23,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 1, column: 23, index: 23 },
+        },
+        exportKind: "value",
+        declaration: {
+          type: "ClassDeclaration",
+          start: 15,
+          end: 23,
+          loc: {
+            start: { line: 1, column: 15, index: 15 },
+            end: { line: 1, column: 23, index: 23 },
+          },
+          id: null,
+          superClass: null,
+          body: {
+            type: "ClassBody",
+            start: 21,
+            end: 23,
+            loc: {
+              start: { line: 1, column: 21, index: 21 },
+              end: { line: 1, column: 23, index: 23 },
+            },
+            body: [],
+          },
+        },
+      },
+    ],
+    sourceType: "module",
+  },
   ExportConst: {
     'type': 'Program',
     'start': 0,

--- a/__test__/export/normal.test.ts
+++ b/__test__/export/normal.test.ts
@@ -42,6 +42,14 @@ describe('normal export', () => {
     equalNode(node, NormalExportSnapshot.ExportDefaultArrowFunction)
   })
 
+  it('export default anonymous class', () => {
+    const node = parseSource(generateSource([
+      `export default class {}`,
+    ]))
+
+    equalNode(node, NormalExportSnapshot.ExportDefaultAnonymousClass)
+  })
+
   it('export const', () => {
     const node = parseSource(generateSource([
       `export const test = '12345'`

--- a/src/index.ts
+++ b/src/index.ts
@@ -3797,7 +3797,7 @@ function tsPlugin(options?: {
 
       parseClassId(
         node: any,
-        isStatement: boolean
+        isStatement: boolean | 'nullableID'
       ): void {
         if ((!isStatement) && this.ts_isContextual(tokTypes.implements)) {
           return
@@ -5006,7 +5006,7 @@ function tsPlugin(options?: {
 
       parseClass(
         node: any,
-        isStatement: boolean | string
+        isStatement: boolean | 'nullableID'
       ): any {
         const oldInAbstractClass = this.inAbstractClass
         this.inAbstractClass = !!(node as any).abstract
@@ -5020,7 +5020,7 @@ function tsPlugin(options?: {
           const oldStrict = this.strict
           this.strict = true
 
-          this.parseClassId(node, Boolean(isStatement))
+          this.parseClassId(node, isStatement)
           this.parseClassSuper(node)
 
           const privateNameMap = this.enterClassBody()

--- a/src/middleware.d.ts
+++ b/src/middleware.d.ts
@@ -155,7 +155,7 @@ export class AcornParseClass extends Parser {
 
   parseParenItem(item: any): any
 
-  parseClassId(node: any, isStatement?: boolean)
+  parseClassId(node: any, isStatement?: boolean | 'nullableID')
 
   parseClassField(field: any): any
 


### PR DESCRIPTION
This PR fixes syntax error in export default anonymous class.

e.g.

```js
export default class {}
```