### PR TITLE
fix: syntax error in async arrow function with one param

### DIFF
--- a/__test__/__snapshot__/function/type.ts
+++ b/__test__/__snapshot__/function/type.ts
@@ -4315,6 +4315,82 @@ const FunctionTypeSnapshot = {
     ],
     sourceType: "module",
   },
+  AsyncArrowFunctionWithOneParam: {
+    type: "Program",
+    start: 0,
+    end: 17,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 1, column: 17, index: 17 },
+    },
+    body: [
+      {
+        type: "ExpressionStatement",
+        start: 0,
+        end: 17,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 1, column: 17, index: 17 },
+        },
+        expression: {
+          type: "AssignmentExpression",
+          start: 0,
+          end: 17,
+          loc: {
+            start: { line: 1, column: 0, index: 0 },
+            end: { line: 1, column: 17, index: 17 },
+          },
+          operator: "=",
+          left: {
+            type: "Identifier",
+            start: 0,
+            end: 1,
+            loc: {
+              start: { line: 1, column: 0, index: 0 },
+              end: { line: 1, column: 1, index: 1 },
+            },
+            name: "a",
+          },
+          right: {
+            type: "ArrowFunctionExpression",
+            start: 4,
+            end: 17,
+            loc: {
+              start: { line: 1, column: 4, index: 4 },
+              end: { line: 1, column: 17, index: 17 },
+            },
+            id: null,
+            expression: false,
+            generator: false,
+            async: true,
+            params: [
+              {
+                type: "Identifier",
+                start: 10,
+                end: 11,
+                loc: {
+                  start: { line: 1, column: 10, index: 10 },
+                  end: { line: 1, column: 11, index: 11 },
+                },
+                name: "x",
+              },
+            ],
+            body: {
+              type: "BlockStatement",
+              start: 15,
+              end: 17,
+              loc: {
+                start: { line: 1, column: 15, index: 15 },
+                end: { line: 1, column: 17, index: 17 },
+              },
+              body: [],
+            },
+          },
+        },
+      },
+    ],
+    sourceType: "module",
+  },  
   DeclareFunctionTypes: {
     'type': 'Program',
     'start': 0,

--- a/__test__/function/type.test.ts
+++ b/__test__/function/type.test.ts
@@ -197,6 +197,14 @@ describe('function type test', () => {
     equalNode(node, FunctionTypeSnapshot.AsyncGeneratorFunction)
   })
 
+  it('async arrow function with one param', () => {
+    const node = parseSource(generateSource([
+      `a = async x => {}`
+    ]))
+
+    equalNode(node, FunctionTypeSnapshot.AsyncArrowFunctionWithOneParam)
+  })
+
   it('declare function types', () => {
     const node = parseSource(generateSource([
       `function test(a: string): string`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3335,6 +3335,28 @@ function tsPlugin(options?: {
           if (this.type === tt.slash) this.readRegexp()
 
           let node, canBeArrow = this['potentialArrowAt'] === this.start
+
+          if (this.type === tt.name || tokenIsIdentifier(this.type)) {
+            let startPos = this.start, startLoc = this.startLoc,
+              containsEsc = this.containsEsc
+            let id = this.parseIdent(false)
+            if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === 'async' && !this.canInsertSemicolon() && this.eat(tt._function)) {
+              this.overrideContext(tokContexts.f_expr)
+              return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit)
+            }
+            if (canBeArrow && !this.canInsertSemicolon()) {
+              if (this.eat(tt.arrow))
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit)
+              if (this.options.ecmaVersion >= 8 && id.name === 'async' && this.type === tt.name && !containsEsc &&
+                (!this.potentialArrowInForAwait || this.value !== 'of' || this.containsEsc)) {
+                id = this.parseIdent(false)
+                if (this.canInsertSemicolon() || !this.eat(tt.arrow))
+                  this.unexpected()
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit)
+              }
+            }
+            return id
+          }
           switch (this.type) {
             case tt._super:
               if (!this['allowSuper'])
@@ -3359,26 +3381,6 @@ function tsPlugin(options?: {
               this.next()
               return this.finishNode(node, 'ThisExpression')
 
-            case tt.name:
-              let startPos = this.start, startLoc = this.startLoc,
-                containsEsc = this.containsEsc
-              let id = this.parseIdent(false)
-              if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === 'async' && !this.canInsertSemicolon() && this.eat(tt._function)) {
-                this.overrideContext(tokContexts.f_expr)
-                return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit)
-              }
-              if (canBeArrow && !this.canInsertSemicolon()) {
-                if (this.eat(tt.arrow))
-                  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit)
-                if (this.options.ecmaVersion >= 8 && id.name === 'async' && this.type === tt.name && !containsEsc &&
-                  (!this.potentialArrowInForAwait || this.value !== 'of' || this.containsEsc)) {
-                  id = this.parseIdent(false)
-                  if (this.canInsertSemicolon() || !this.eat(tt.arrow))
-                    this.unexpected()
-                  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit)
-                }
-              }
-              return id
             case tt.regexp:
               let value = this.value
               node = this.parseLiteral(value.value)


### PR DESCRIPTION
See the link PR before merging this PR.
https://github.com/TyrealHu/acorn-typescript/pull/18#issuecomment-1565282587

If you merge #18, we don't need to change this PR.

---

This PR fixes syntax error in async arrow function with one param omit paren.

e.g.

```js
a = async x => {}
```