### PR TITLE
fix: syntax error in escaped keyword property

### DIFF
--- a/__test__/__snapshot__/class/type.ts
+++ b/__test__/__snapshot__/class/type.ts
@@ -10742,7 +10742,90 @@ const ClassTypeSnapshot = {
       }
     ],
     'sourceType': 'module'
-  }
+  },
+  EscapedKeywordProperty: {
+    type: "Program",
+    start: 0,
+    end: 28,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 3, column: 1, index: 28 },
+    },
+    body: [
+      {
+        type: "ClassDeclaration",
+        start: 0,
+        end: 28,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 3, column: 1, index: 28 },
+        },
+        id: {
+          type: "Identifier",
+          start: 6,
+          end: 7,
+          loc: {
+            start: { line: 1, column: 6, index: 6 },
+            end: { line: 1, column: 7, index: 7 },
+          },
+          name: "C",
+        },
+        superClass: null,
+        body: {
+          type: "ClassBody",
+          start: 8,
+          end: 28,
+          loc: {
+            start: { line: 1, column: 8, index: 8 },
+            end: { line: 3, column: 1, index: 28 },
+          },
+          body: [
+            {
+              type: "PropertyDefinition",
+              start: 11,
+              end: 26,
+              loc: {
+                start: { line: 2, column: 1, index: 11 },
+                end: { line: 2, column: 16, index: 26 },
+              },
+              static: false,
+              computed: false,
+              key: {
+                type: "Identifier",
+                start: 11,
+                end: 18,
+                loc: {
+                  start: { line: 2, column: 1, index: 11 },
+                  end: { line: 2, column: 8, index: 18 },
+                },
+                name: "in",
+              },
+              typeAnnotation: {
+                type: "TSTypeAnnotation",
+                start: 18,
+                end: 26,
+                loc: {
+                  start: { line: 2, column: 8, index: 18 },
+                  end: { line: 2, column: 16, index: 26 },
+                },
+                typeAnnotation: {
+                  type: "TSStringKeyword",
+                  start: 20,
+                  end: 26,
+                  loc: {
+                    start: { line: 2, column: 10, index: 20 },
+                    end: { line: 2, column: 16, index: 26 },
+                  },
+                },
+              },
+              value: null,
+            },
+          ],
+        },
+      },
+    ],
+    sourceType: "module",
+  }  
 }
 
 export default ClassTypeSnapshot

--- a/__test__/__snapshot__/expression/variables.ts
+++ b/__test__/__snapshot__/expression/variables.ts
@@ -4302,7 +4302,79 @@ const VariablesTypeSnapshot = {
       }
     ],
     'sourceType': 'module'
-  }
+  },
+  OneAsNumber: {
+    type: "Program",
+    start: 0,
+    end: 22,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 1, column: 22, index: 22 },
+    },
+    body: [
+      {
+        type: "VariableDeclaration",
+        start: 0,
+        end: 22,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 1, column: 22, index: 22 },
+        },
+        declarations: [
+          {
+            type: "VariableDeclarator",
+            start: 4,
+            end: 22,
+            loc: {
+              start: { line: 1, column: 4, index: 4 },
+              end: { line: 1, column: 22, index: 22 },
+            },
+            id: {
+              type: "Identifier",
+              start: 4,
+              end: 8,
+              loc: {
+                start: { line: 1, column: 4, index: 4 },
+                end: { line: 1, column: 8, index: 8 },
+              },
+              name: "test",
+            },
+            init: {
+              type: "TSAsExpression",
+              start: 11,
+              end: 22,
+              loc: {
+                start: { line: 1, column: 11, index: 11 },
+                end: { line: 1, column: 22, index: 22 },
+              },
+              expression: {
+                type: "Literal",
+                start: 11,
+                end: 12,
+                loc: {
+                  start: { line: 1, column: 11, index: 11 },
+                  end: { line: 1, column: 12, index: 12 },
+                },
+                value: 1,
+                raw: "1",
+              },
+              typeAnnotation: {
+                type: "TSNumberKeyword",
+                start: 16,
+                end: 22,
+                loc: {
+                  start: { line: 1, column: 16, index: 16 },
+                  end: { line: 1, column: 22, index: 22 },
+                },
+              },
+            },
+          },
+        ],
+        kind: "let",
+      },
+    ],
+    sourceType: "module",
+  }  
 }
 
 export default VariablesTypeSnapshot

--- a/__test__/arrow-function/type.test.ts
+++ b/__test__/arrow-function/type.test.ts
@@ -7,7 +7,6 @@ describe('arrow-function type test', () => {
       `(x = 42): void => {}`
     ]))
 
-    console.log(JSON.stringify(node, null, 2))
     equalNode(node, ArrowFunctionTypeSnapshot.AssignmentPattern)
   })
 })

--- a/__test__/class/type.test.ts
+++ b/__test__/class/type.test.ts
@@ -275,7 +275,17 @@ describe('class', () => {
       `}`
     ]))
 
-    console.log(JSON.stringify(node, null, 2))
+    equalNode(node, ClassTypeSnapshot.Accessor)
+  })
+
+  it.only('escaped keyword property ', () => {
+    const node = parseSource(generateSource([
+      `class C {`,
+      ` \\u0069n: string`,
+      `}`
+    ]))
+
+    equalNode(node, ClassTypeSnapshot.EscapedKeywordProperty)
   })
 })
 

--- a/__test__/expression/variables.test.ts
+++ b/__test__/expression/variables.test.ts
@@ -193,7 +193,6 @@ describe('variables declaration', () => {
       `let test = 1 as number`
     ]))
 
-    console.log(JSON.stringify(node, null, 2))
-    // equalNode(node, VariablesTypeSnapshot.ExpressionEqualAsyncArrowFunction)
+    equalNode(node, VariablesTypeSnapshot.OneAsNumber)
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -2126,7 +2126,7 @@ function tsPlugin(options?: {
         // more things are considered modifiers there.
         // This implementation only handles modifiers not handled by @babel/parser itself. And "static".
         // TODO: Would be nice to avoid lookahead. Want a hasLineBreakUpNext() method...
-        this.next()
+        this.next(true)
         return this.tsTokenCanFollowModifier()
       }
 


### PR DESCRIPTION
This PR fixes syntax error in escaped keyword property.

e.g.

```ts
class C {
 \\u0069n: string // <- escaped `in`
}
```
