### PR TITLE
fix: syntax error in catch redeclared var statement captured

### DIFF
--- a/__test__/__snapshot__/try/index.ts
+++ b/__test__/__snapshot__/try/index.ts
@@ -474,6 +474,140 @@ const TryTypeSnapshot = {
       }
     ],
     'sourceType': 'module'
+  },
+  CatchRedeclaredVarStatementCaptured: {
+    type: "Program",
+    start: 0,
+    end: 80,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 5, column: 1, index: 80 },
+    },
+    body: [
+      {
+        type: "TryStatement",
+        start: 0,
+        end: 80,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 5, column: 1, index: 80 },
+        },
+        block: {
+          type: "BlockStatement",
+          start: 4,
+          end: 28,
+          loc: {
+            start: { line: 1, column: 4, index: 4 },
+            end: { line: 3, column: 1, index: 28 },
+          },
+          body: [
+            {
+              type: "ThrowStatement",
+              start: 8,
+              end: 26,
+              loc: {
+                start: { line: 2, column: 2, index: 8 },
+                end: { line: 2, column: 20, index: 26 },
+              },
+              argument: {
+                type: "NewExpression",
+                start: 14,
+                end: 25,
+                loc: {
+                  start: { line: 2, column: 8, index: 14 },
+                  end: { line: 2, column: 19, index: 25 },
+                },
+                callee: {
+                  type: "Identifier",
+                  start: 18,
+                  end: 23,
+                  loc: {
+                    start: { line: 2, column: 12, index: 18 },
+                    end: { line: 2, column: 17, index: 23 },
+                  },
+                  name: "Error",
+                },
+                arguments: [],
+              },
+            },
+          ],
+        },
+        handler: {
+          type: "CatchClause",
+          start: 29,
+          end: 80,
+          loc: {
+            start: { line: 3, column: 2, index: 29 },
+            end: { line: 5, column: 1, index: 80 },
+          },
+          param: {
+            type: "Identifier",
+            start: 36,
+            end: 39,
+            loc: {
+              start: { line: 3, column: 9, index: 36 },
+              end: { line: 3, column: 12, index: 39 },
+            },
+            name: "foo",
+          },
+          body: {
+            type: "BlockStatement",
+            start: 41,
+            end: 80,
+            loc: {
+              start: { line: 3, column: 14, index: 41 },
+              end: { line: 5, column: 1, index: 80 },
+            },
+            body: [
+              {
+                type: "VariableDeclaration",
+                start: 45,
+                end: 78,
+                loc: {
+                  start: { line: 4, column: 2, index: 45 },
+                  end: { line: 4, column: 35, index: 78 },
+                },
+                declarations: [
+                  {
+                    type: "VariableDeclarator",
+                    start: 49,
+                    end: 77,
+                    loc: {
+                      start: { line: 4, column: 6, index: 49 },
+                      end: { line: 4, column: 34, index: 77 },
+                    },
+                    id: {
+                      type: "Identifier",
+                      start: 49,
+                      end: 52,
+                      loc: {
+                        start: { line: 4, column: 6, index: 49 },
+                        end: { line: 4, column: 9, index: 52 },
+                      },
+                      name: "foo",
+                    },
+                    init: {
+                      type: "Literal",
+                      start: 55,
+                      end: 77,
+                      loc: {
+                        start: { line: 4, column: 12, index: 55 },
+                        end: { line: 4, column: 34, index: 77 },
+                      },
+                      value: "initializer in catch",
+                      raw: '"initializer in catch"',
+                    },
+                  },
+                ],
+                kind: "var",
+              },
+            ],
+          },
+        },
+        finalizer: null,
+      },
+    ],
+    sourceType: "module",
   }
 }
 

--- a/__test__/try/type.test.ts
+++ b/__test__/try/type.test.ts
@@ -22,4 +22,16 @@ describe('try statement', function() {
     // console.log(JSON.stringify(node, null, 2))
     equalNode(node, TryTypeSnapshot.WithType)
   })
+
+  it('catch redeclared var statement captured', function() {
+    const node = parseSource(generateSource([
+      `try {`,
+      `  throw new Error();`,
+      `} catch (foo) {`,
+      `  var foo = "initializer in catch";`,
+      `}`
+    ]))
+
+    equalNode(node, TryTypeSnapshot.CatchRedeclaredVarStatementCaptured)
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,9 +15,8 @@ import {
   BIND_TS_INTERFACE,
   BIND_TS_NAMESPACE,
   BIND_TS_TYPE,
-  SCOPE_OTHER,
-  SCOPE_SIMPLE_CATCH,
-  SCOPE_TS_MODULE
+  TS_SCOPE_OTHER,
+  TS_SCOPE_TS_MODULE
 } from './scopeflags'
 import { skipWhiteSpaceToLineBreak } from './whitespace'
 import {
@@ -993,7 +992,7 @@ function tsPlugin(options?: {
 
       tsParseModuleBlock(): Node {
         const node = this.startNode()
-        super.enterScope(SCOPE_OTHER)
+        super.enterScope(TS_SCOPE_OTHER)
         this.expect(tt.braceL)
         // Inside of a module block is considered "top-level", meaning it can have imports and exports.
         node.body = []
@@ -1023,7 +1022,7 @@ function tsPlugin(options?: {
         }
         if (this.match(tt.braceL)) {
 
-          super.enterScope(SCOPE_TS_MODULE)
+          super.enterScope(TS_SCOPE_TS_MODULE)
 
           node.body = this.tsParseModuleBlock()
 
@@ -2588,7 +2587,7 @@ function tsPlugin(options?: {
             // Would like to use tsParseAmbientExternalModuleDeclaration here, but already ran past "global".
             if (this.match(tt.braceL)) {
 
-              super.enterScope(SCOPE_TS_MODULE)
+              super.enterScope(TS_SCOPE_TS_MODULE)
               const mod = node
               mod.global = true
               mod.id = expr
@@ -2695,7 +2694,7 @@ function tsPlugin(options?: {
           node.body = inner
         } else {
 
-          super.enterScope(SCOPE_TS_MODULE)
+          super.enterScope(TS_SCOPE_TS_MODULE)
 
           node.body = this.tsParseModuleBlock()
 
@@ -4945,7 +4944,7 @@ function tsPlugin(options?: {
       parseCatchClauseParam() {
         const param = this.parseBindingAtom()
         let simple = param.type === 'Identifier'
-        this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0)
+        this.enterScope(simple ? acornScope.SCOPE_SIMPLE_CATCH : 0)
         this.checkLValPattern(param, simple ? acornScope.BIND_SIMPLE_CATCH : acornScope.BIND_LEXICAL)
         // start add ts support
         const type = this.tsTryParseTypeAnnotation()

--- a/src/scopeflags.ts
+++ b/src/scopeflags.ts
@@ -1,28 +1,9 @@
 // Each scope gets a bitset that may contain these flags
 // prettier-ignore
-export const SCOPE_OTHER        = 0b000000000,
-  SCOPE_PROGRAM      = 0b000000001,
-  SCOPE_FUNCTION     = 0b000000010,
-  SCOPE_ARROW        = 0b000000100,
-  SCOPE_SIMPLE_CATCH = 0b000001000,
-  SCOPE_SUPER        = 0b000010000,
-  SCOPE_DIRECT_SUPER = 0b000100000,
-  SCOPE_CLASS        = 0b001000000,
-  SCOPE_STATIC_BLOCK = 0b010000000,
-  SCOPE_TS_MODULE    = 0b100000000,
-  SCOPE_VAR = SCOPE_PROGRAM | SCOPE_FUNCTION | SCOPE_TS_MODULE;
-
-export type ScopeFlags =
-  | typeof SCOPE_OTHER
-  | typeof SCOPE_PROGRAM
-  | typeof SCOPE_FUNCTION
-  | typeof SCOPE_VAR
-  | typeof SCOPE_ARROW
-  | typeof SCOPE_SIMPLE_CATCH
-  | typeof SCOPE_SUPER
-  | typeof SCOPE_DIRECT_SUPER
-  | typeof SCOPE_CLASS
-  | typeof SCOPE_STATIC_BLOCK;
+export const
+  // Up to 0b00100000000 is reserved in acorn.
+  TS_SCOPE_OTHER        = 0b01000000000,
+  TS_SCOPE_TS_MODULE    = 0b10000000000;
 
 // These flags are meant to be _only_ used inside the Scope class (or subclasses).
 // prettier-ignore


### PR DESCRIPTION
This PR fixes syntax error in catch redeclared var statement captured.

e.g.

```js
try {
} catch (e) {
  var e = 'foo'
}


```
