### PR TITLE
fix: to raise error in multiple constructors

### DIFF
--- a/__test__/__snapshot__/class/type.ts
+++ b/__test__/__snapshot__/class/type.ts
@@ -10825,7 +10825,132 @@ const ClassTypeSnapshot = {
       },
     ],
     sourceType: "module",
-  }  
+  },
+  ConstructorSignature: {
+    type: "Program",
+    start: 0,
+    end: 43,
+    loc: {
+      start: { line: 1, column: 0, index: 0 },
+      end: { line: 4, column: 1, index: 43 },
+    },
+    body: [
+      {
+        type: "ClassDeclaration",
+        start: 0,
+        end: 43,
+        loc: {
+          start: { line: 1, column: 0, index: 0 },
+          end: { line: 4, column: 1, index: 43 },
+        },
+        id: {
+          type: "Identifier",
+          start: 6,
+          end: 7,
+          loc: {
+            start: { line: 1, column: 6, index: 6 },
+            end: { line: 1, column: 7, index: 7 },
+          },
+          name: "C",
+        },
+        superClass: null,
+        body: {
+          type: "ClassBody",
+          start: 8,
+          end: 43,
+          loc: {
+            start: { line: 1, column: 8, index: 8 },
+            end: { line: 4, column: 1, index: 43 },
+          },
+          body: [
+            {
+              type: "MethodDefinition",
+              start: 11,
+              end: 24,
+              loc: {
+                start: { line: 2, column: 1, index: 11 },
+                end: { line: 2, column: 14, index: 24 },
+              },
+              static: false,
+              computed: false,
+              key: {
+                type: "Identifier",
+                start: 11,
+                end: 22,
+                loc: {
+                  start: { line: 2, column: 1, index: 11 },
+                  end: { line: 2, column: 12, index: 22 },
+                },
+                name: "constructor",
+              },
+              kind: "constructor",
+              value: {
+                type: "TSDeclareMethod",
+                start: 22,
+                end: 24,
+                loc: {
+                  start: { line: 2, column: 12, index: 22 },
+                  end: { line: 2, column: 14, index: 24 },
+                },
+                id: null,
+                expression: false,
+                generator: false,
+                async: false,
+                params: [],
+              },
+            },
+            {
+              type: "MethodDefinition",
+              start: 26,
+              end: 41,
+              loc: {
+                start: { line: 3, column: 1, index: 26 },
+                end: { line: 3, column: 16, index: 41 },
+              },
+              static: false,
+              computed: false,
+              key: {
+                type: "Identifier",
+                start: 26,
+                end: 37,
+                loc: {
+                  start: { line: 3, column: 1, index: 26 },
+                  end: { line: 3, column: 12, index: 37 },
+                },
+                name: "constructor",
+              },
+              kind: "constructor",
+              value: {
+                type: "FunctionExpression",
+                start: 37,
+                end: 41,
+                loc: {
+                  start: { line: 3, column: 12, index: 37 },
+                  end: { line: 3, column: 16, index: 41 },
+                },
+                id: null,
+                expression: false,
+                generator: false,
+                async: false,
+                params: [],
+                body: {
+                  type: "BlockStatement",
+                  start: 39,
+                  end: 41,
+                  loc: {
+                    start: { line: 3, column: 14, index: 39 },
+                    end: { line: 3, column: 16, index: 41 },
+                  },
+                  body: [],
+                },
+              },
+            },
+          ],
+        },
+      },
+    ],
+    sourceType: "module",
+  }
 }
 
 export default ClassTypeSnapshot

--- a/__test__/class/type.test.ts
+++ b/__test__/class/type.test.ts
@@ -278,7 +278,7 @@ describe('class', () => {
     equalNode(node, ClassTypeSnapshot.Accessor)
   })
 
-  it.only('escaped keyword property ', () => {
+  it('escaped keyword property ', () => {
     const node = parseSource(generateSource([
       `class C {`,
       ` \\u0069n: string`,
@@ -286,6 +286,28 @@ describe('class', () => {
     ]))
 
     equalNode(node, ClassTypeSnapshot.EscapedKeywordProperty)
+  })
+
+  it('duplicate constructor', () => {
+    expect(() => {
+      parseSource(generateSource([
+        `class C {`,
+        ` constructor(){}`,
+        ` constructor(){}`,
+        `}`
+      ]))
+    }).toThrowError()
+  })
+
+  it('constructor signature', () => {
+    const node = parseSource(generateSource([
+      `class C {`,
+      ` constructor()`,
+      ` constructor(){}`,
+      `}`
+    ]))
+
+    equalNode(node, ClassTypeSnapshot.ConstructorSignature)
   })
 })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5025,7 +5025,7 @@ function tsPlugin(options?: {
 
             if (element) {
               classBody.body.push(element)
-              if (element.type === 'MethodDefinition' && element.kind === 'constructor') {
+              if (element.type === 'MethodDefinition' && element.kind === 'constructor' && element.value.type === 'FunctionExpression') {
                 if (hadConstructor) {
                   this.raiseRecoverable(element.start, 'Duplicate constructor in the same class')
                 }
@@ -5343,8 +5343,6 @@ function tsPlugin(options?: {
 
       raiseCommonCheck(pos: number, message: string, recoverable: boolean) {
         switch (message) {
-          case 'Duplicate constructor in the same class':
-            return
           case 'Comma is not permitted after the rest element': {
             if (
               this.isAmbientContext &&


### PR DESCRIPTION
This PR fixes the parser to raise a syntax error when a class has multiple constructors.
However, the constructor signature handles it so that no error occurs.