### PR TITLE
chore: skip test262 which is not yet resolved

### DIFF
--- a/test262/run_test262.ts
+++ b/test262/run_test262.ts
@@ -27,8 +27,6 @@ const WHITELIST: string[] = [
   "language/identifiers/val-this.js",
   "language/identifiers/val-this-via-escape-hex.js",
   "language/identifiers/val-this-via-escape-hex4.js",
-  // escaped `static`. e.g. `class { st\u0061tic m() {} }`
-  "language/statements/class/syntax/escaped-static.js",
 ].flatMap((s) => [s + " (default)", s + " (strict mode)"]);
 
 run(

--- a/test262/run_test262.ts
+++ b/test262/run_test262.ts
@@ -9,9 +9,27 @@ const UNSUPPORTED_FEATURES: string[] = [
   "regexp-v-flag",
   "regexp-duplicate-named-groups",
   "import-assertions",
+  "decorators",
 ];
 
-const WHITELIST: string[] = [];
+const SKIP_FILES: string[] = [
+  // `1 < 2 > 3;` cannot be parsed well.
+  // This is because `< 2 >` is judged as TypeArguments.
+  // See https://github.com/TyrealHu/acorn-typescript/issues/21
+  "test/language/punctuators/S7.7_A1.js",
+];
+
+
+// Some keywords still don't throw an error.
+// See https://github.com/TyrealHu/acorn-typescript/issues/23
+const WHITELIST: string[] = [
+  // `this` variable name. e.g. `var this = 42`
+  "language/identifiers/val-this.js",
+  "language/identifiers/val-this-via-escape-hex.js",
+  "language/identifiers/val-this-via-escape-hex4.js",
+  // escaped `static`. e.g. `class { st\u0061tic m() {} }`
+  "language/statements/class/syntax/escaped-static.js",
+].flatMap((s) => [s + " (default)", s + " (strict mode)"]);
 
 run(
   (content, { sourceType }) => {
@@ -25,8 +43,9 @@ run(
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: (test) => {
       return (
-        test.attrs.features &&
-        UNSUPPORTED_FEATURES.some((f) => test.attrs.features.includes(f))
+        (test.attrs.features &&
+          UNSUPPORTED_FEATURES.some((f) => test.attrs.features.includes(f))) ||
+        SKIP_FILES.includes(test.file)
       );
     },
     whitelist: WHITELIST.map((filename) =>


### PR DESCRIPTION
This PR changes the unresolved test262 tests to be skipped.
The tests to skip are tests for ES next features, or opened an issue.

If #22, and #25 are also merged, I think all workflow jobs will be green.