### PR TITLE
fix: to raise error in escaped static method

### DIFF
--- a/__test__/class/type.test.ts
+++ b/__test__/class/type.test.ts
@@ -148,6 +148,17 @@ describe('class', () => {
     equalNode(node, ClassTypeSnapshot.StaticGetterSetter)
   })
 
+  it('escaped static method ', () => {
+    // See: https://github.com/tc39/test262/blob/main/test/language/statements/class/syntax/escaped-static.js
+    expect(() => {
+      parseSource(generateSource([
+        `class C {`,
+        ` st\\u0061tic m() {}`,
+        `}`
+      ]))
+    }).toThrowError()
+  })
+
   it('private class method', () => {
     const node = parseSource(generateSource([
       `class Student {`,
@@ -278,7 +289,7 @@ describe('class', () => {
     equalNode(node, ClassTypeSnapshot.Accessor)
   })
 
-  it.only('escaped keyword property ', () => {
+  it('escaped keyword property ', () => {
     const node = parseSource(generateSource([
       `class C {`,
       ` \\u0069n: string`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2139,7 +2139,7 @@ function tsPlugin(options?: {
         }
 
         const modifier = this.value as any
-        if (allowedModifiers.indexOf(modifier) !== -1) {
+        if (allowedModifiers.indexOf(modifier) !== -1 && !this.containsEsc) {
           if (stopOnStartOfClassStaticBlock && this.tsIsStartOfStaticBlocks()) {
             return undefined
           }


### PR DESCRIPTION
This PR fixes the parser to raise a syntax error when a class has escaped static method.

Related to #23