### PR TITLE
chore: fix test262

### DIFF
--- a/__test__/run_test262.ts
+++ b/__test__/run_test262.ts
@@ -38,7 +38,7 @@ run(
     });
   },
   {
-    testsDirectory: path.dirname(require.resolve("../package.json")),
+    testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: (test) => {
       return (
         (test.attrs.features &&


### PR DESCRIPTION
The latest master branch no longer runs test262 due to an error. This PR fixes test262 to run.