### PR TITLE
cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Alternative, TypeScript parser",
   "source": "src/index.ts",
   "main": "lib/index.js",
+  "type": "commonjs",
   "types": "lib/index.d.ts",
   "exports": {
     ".": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Alternative, TypeScript parser",
   "source": "src/index.ts",
   "main": "lib/index.js",
-  "type": "commonjs",
   "types": "lib/index.d.ts",
   "exports": {
     ".": [

--- a/package.json
+++ b/package.json
@@ -4,8 +4,17 @@
   "description": "Alternative, TypeScript parser",
   "source": "src/index.ts",
   "main": "lib/index.js",
-  "module": "lib/index.mjs",
   "types": "lib/index.d.ts",
+  "exports": {
+    ".": [
+      {
+        "types": "./lib/index.d.ts",
+        "import": "./lib/index.mjs",
+        "default": "./lib/index.js"
+      },
+      "./lib/index.js"
+    ]
+  },
   "scripts": {
     "build": "microbundle --define process.env.NODE_ENV=production --no-sourcemap --tsconfig ./tsconfig.json --format esm,cjs",
     "test": "jest --collect-coverage --silent",
@@ -13,16 +22,6 @@
     "release-major": "yarn build && yarn test && standard-version --release-as major",
     "release-minor": "yarn build && yarn test && standard-version --release-as minor",
     "release-patch": "yarn build && yarn test && standard-version --release-as patch"
-  },
-  "exports": {
-    ".": [
-      {
-        "import": "./lib/index.mjs",
-        "require": "./lib/index.js",
-        "default": "./lib/index.js"
-      },
-      "./lib/index.js"
-    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "exports": {
     ".": [
       {
-        "types": "./lib/index.d.ts",
         "import": "./lib/index.mjs",
         "default": "./lib/index.js"
       },


### PR DESCRIPTION
- put `main` and `exports` next to each other to make it easy to see the entry points
- removed `module`. it will be ignored since `exports` is present
- removed `require` since it duplicated `default`